### PR TITLE
Android 6.0 release removes support for the Apache HTTP client

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,3 +1,4 @@
+
 apply plugin: 'com.android.application'
 
 android {
@@ -30,4 +31,7 @@ dependencies {
     compile 'com.pubnub:pubnub-android:3.7.4'
     compile 'io.pristine:libjingle:9694@aar'
     compile project(':pnwebrtc')
+}
+android {
+    useLibrary 'org.apache.http.legacy'
 }


### PR DESCRIPTION
HttpClient was deprecated in Android 5.1 and is removed from the Android SDK in Android 6.0. 
There is a workaround to continue using HttpClient in Android 6.0 with Android Studio,